### PR TITLE
Add list of admins and board members

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # governance
-The governance process and model for the QuTiP Project
+The governance process and model for the QuTiP Project.
+
+
+# charter
+The charter document for the governance of the QuTiP Project can be found [here](governance.md).
+
+# admins
+The members of the admin team for the QuTiP Project can be found [here](admins.md).
+
+# board
+The members of the board for the QuTiP Project can be found [here](board.md).
+

--- a/admins.md
+++ b/admins.md
@@ -1,6 +1,6 @@
  # QuTiP Admin Team
 
-The functioning of the board of the QuTiP project can be found in the [governance document](governance.md#2-admin-team). The current members of the board are:
+The functioning of the admin team of the QuTiP project can be found in the [governance document](governance.md#2-admin-team). The current members of the admin team are:
 
 - Shahnawaz Ahmed
 - Eric Giguere

--- a/admins.md
+++ b/admins.md
@@ -9,3 +9,4 @@ The functioning of the admin team of the QuTiP project can be found in the [gove
 - Jake Lishman
 - Alex Pitchford
 - Nathan Shammah
+- Simon Cross

--- a/admins.md
+++ b/admins.md
@@ -3,7 +3,7 @@
 The functioning of the admin team of the QuTiP project can be found in the [governance document](governance.md#2-admin-team). The current members of the admin team are:
 
 - Shahnawaz Ahmed
-- Eric Giguere
+- Eric Giguère
 - Neill Lambert
 - Boxi Li
 - Jake Lishman

--- a/admins.md
+++ b/admins.md
@@ -3,10 +3,10 @@
 The functioning of the admin team of the QuTiP project can be found in the [governance document](governance.md#2-admin-team). The current members of the admin team are:
 
 - Shahnawaz Ahmed
+- Simon Cross
 - Eric Giguère
 - Neill Lambert
 - Boxi Li
 - Jake Lishman
 - Alex Pitchford
 - Nathan Shammah
-- Simon Cross

--- a/admins.md
+++ b/admins.md
@@ -1,0 +1,11 @@
+ # QuTiP Admin Team
+
+The functioning of the board of the QuTiP project can be found in the [governance document](governance.md#2-admin-team). The current members of the board are:
+
+- Shahnawaz Ahmed
+- Eric Giguere
+- Neill Lambert
+- Boxi Li
+- Jake Lishman
+- Alex Pitchford
+- Nathan Shammah

--- a/board.md
+++ b/board.md
@@ -1,0 +1,9 @@
+ # QuTiP Board Members
+
+The functioning of the board of the QuTiP project can be found in the [governance document](governance.md#3-board). The current members of the board are:
+
+- Daniel Burgarth
+- Anton Frisk Kockum
+- Robert Johansson
+- Franco Nori
+- Will Zeng


### PR DESCRIPTION
This is taking a first stab at it. Updates on the QuTiP website will give more details, e.g., affiliations, biographic info, etc. 